### PR TITLE
feat: support ESLint 9.3.0 

### DIFF
--- a/.changeset/purple-terms-fold.md
+++ b/.changeset/purple-terms-fold.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": patch
+---
+
+feat: support ESLint 9.3.0

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -210,7 +210,7 @@ function buildSourceCode() {
     eslintPackageJsonPath,
     "../lib/source-code/index.js",
   );
-  return build(sourceCodePath, ["path"]);
+  return build(sourceCodePath, ["path", "node:path", "assert", "node:assert"]);
 }
 
 function buildRules() {
@@ -266,7 +266,7 @@ function bundle(
     inject: [path.join(dirname, "../shim/process-shim.mjs")],
   });
 
-  return `${result.outputFiles[0].text}`;
+  return result.outputFiles[0].text;
 }
 
 function transform(
@@ -277,7 +277,7 @@ function transform(
   const injectSources: { id: string; source: string; module: string }[] = [
     ...injects.map((inject) => ({
       id: `$inject_${inject.replace(/[^\w$]/giu, "_")}`,
-      source: inject,
+      source: inject.replace(/^node:/u, ""),
       module: inject,
     })),
     ...Object.entries(alias).map(([module, source]) => ({

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -194,9 +194,13 @@ function buildLinter() {
     eslintPackageJsonPath,
     "../lib/rules/index.js",
   );
-  const code = build(linterPath, ["path", "assert", "util"], {
-    [rulesPath]: virtualRulesModuleId,
-  });
+  const code = build(
+    linterPath,
+    ["path", "node:path", "assert", "node:assert", "util"],
+    {
+      [rulesPath]: virtualRulesModuleId,
+    },
+  );
   return code;
 }
 

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -219,7 +219,7 @@ function buildRules() {
     eslintPackageJsonPath,
     "../lib/rules/index.js",
   );
-  return build(rulesPath, ["path"]);
+  return build(rulesPath, ["path", "node:path"]);
 }
 
 function buildPackageJSON() {

--- a/tests/fixtures/build-test-v8/src/index.ts
+++ b/tests/fixtures/build-test-v8/src/index.ts
@@ -4,7 +4,7 @@ import { name } from "eslint/package.json";
 import * as TSESLintUtils from "@typescript-eslint/utils";
 import * as TSESLintPlugin from "@typescript-eslint/eslint-plugin";
 
-const linter = new Linter();
+const linter = new Linter({ configType: "eslintrc" });
 
 export function lint(): Linter.LintMessage[] {
   return linter.verify("const a = 1", {

--- a/tests/fixtures/build-test/src/index.ts
+++ b/tests/fixtures/build-test/src/index.ts
@@ -4,7 +4,7 @@ import { name } from "eslint/package.json";
 import * as TSESLintUtils from "@typescript-eslint/utils";
 import * as TSESLintPlugin from "@typescript-eslint/eslint-plugin";
 
-const linter = new Linter();
+const linter = new Linter({ configType: "eslintrc" });
 
 export function lint(): Linter.LintMessage[] {
   return linter.verify("const a = 1", [


### PR DESCRIPTION
https://github.com/eslint/eslint/pull/18434 added the `node:` prefix to be used for imports from node. And it will breaks this plugin.

This is blocker of https://github.com/sveltejs/eslint-plugin-svelte/pull/759