### PR TITLE
chore: remove unused argument `args` from require function

### DIFF
--- a/.changeset/polite-eyes-know.md
+++ b/.changeset/polite-eyes-know.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": patch
+---
+
+chore: remove unused argument from require function

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -296,7 +296,7 @@ ${injectSources
 const $_injects_$ = {${injectSources
     .map(({ id, module }) => `${JSON.stringify(module)}:${id}`)
     .join(",\n")}};
-function require(module, ...args) {
+function require(module) {
 	const mod = $_injects_$[module]
 	return mod.default || mod
 }


### PR DESCRIPTION
This is just remove unused function.