### PR TITLE
fix: normalize module path to prevent unintentional passing mismatches

### DIFF
--- a/.changeset/rotten-bulldogs-exist.md
+++ b/.changeset/rotten-bulldogs-exist.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": patch
+---
+
+fix: normalize module path to prevent unintentional passing mismatches

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -64,6 +64,10 @@ export default {
 };
 `;
 
+function resolveAndNormalizePath(...paths: string[]) {
+  return path.normalize(path.resolve(...paths));
+}
+
 export default function eslint4b(): VitePlugin {
   return {
     name: "vite-plugin-eslint4b",
@@ -86,10 +90,10 @@ export default function eslint4b(): VitePlugin {
       result.resolve.alias.eslint = virtualESLintModuleId;
 
       if (!hasAlias("path")) {
-        result.resolve.alias.path = path.join(dirname, "../shim/path-shim.mjs");
+        result.resolve.alias.path = path.normalize(path.join(dirname, "../shim/path-shim.mjs"));
       }
       if (!hasAlias("fs")) {
-        result.resolve.alias.fs = path.join(dirname, "../shim/fs-shim.mjs");
+        result.resolve.alias.fs = path.normalize(path.join(dirname, "../shim/fs-shim.mjs"));
       }
 
       if (config.define?.["process.env.NODE_DEBUG"] === undefined) {
@@ -186,11 +190,11 @@ function requireResolved(targetPath: string) {
 
 function buildLinter() {
   const eslintPackageJsonPath = requireResolved("eslint/package.json");
-  const linterPath = path.resolve(
+  const linterPath = resolveAndNormalizePath(
     eslintPackageJsonPath,
     "../lib/linter/linter.js",
   );
-  const rulesPath = path.resolve(
+  const rulesPath = resolveAndNormalizePath(
     eslintPackageJsonPath,
     "../lib/rules/index.js",
   );
@@ -202,7 +206,7 @@ function buildLinter() {
 
 function buildSourceCode() {
   const eslintPackageJsonPath = requireResolved("eslint/package.json");
-  const sourceCodePath = path.resolve(
+  const sourceCodePath = resolveAndNormalizePath(
     eslintPackageJsonPath,
     "../lib/source-code/index.js",
   );
@@ -211,7 +215,7 @@ function buildSourceCode() {
 
 function buildRules() {
   const eslintPackageJsonPath = requireResolved("eslint/package.json");
-  const rulesPath = path.resolve(
+  const rulesPath = resolveAndNormalizePath(
     eslintPackageJsonPath,
     "../lib/rules/index.js",
   );
@@ -259,7 +263,7 @@ function bundle(
     bundle: true,
     external,
     write: false,
-    inject: [path.join(dirname, "../shim/process-shim.mjs")],
+    inject: [path.normalize(path.join(dirname, "../shim/process-shim.mjs"))],
   });
 
   return `${result.outputFiles[0].text}`;
@@ -285,7 +289,7 @@ function transform(
 
   injectSources.forEach((s) => {
     if (path.isAbsolute(s.module)) {
-      s.module = `./${path.relative(process.cwd(), s.module)}`;
+      s.module = path.normalize(`./${path.relative(process.cwd(), s.module)}`);
     }
   });
 


### PR DESCRIPTION
Without this PR, we can not build document site on `eslint-plugin-svelte`.
https://github.com/sveltejs/eslint-plugin-svelte/pull/759

When we run `pnpm build` command at `docs-svelte-kit` directory, we got below error.

```
baseballyama@Flyle docs-svelte-kit % pnpm docs:build

> docs@ docs:build /Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit
> pnpm run svelte-kit build


> docs@ svelte-kit /Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit
> env-cmd -e sveltekit node node_modules/vite/bin/vite.js "build"

build@ /Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/node_modules/assert
4:44:10 PM [vite-plugin-svelte] You are using Svelte 5.0.0-next.130. Svelte 5 support is experimental, breaking changes can occur in any release until this notice is removed.
work in progress:
 - svelte-inspector is disabled until dev mode implements node to code mapping

You have specified a baseUrl and/or paths in your tsconfig.json which interferes with SvelteKit's auto-generated tsconfig.json. Remove it to avoid problems with intellisense. For path aliases, use `kit.alias` instead: https://kit.svelte.dev/docs/configuration#alias
vite v5.2.11 building SSR bundle for production...
transforming (234) src/lib/eslint/scripts/monaco-loader.jsThe glob option "as" has been deprecated in favour of "query". Please update `as: 'raw'` to `query: '?raw', import: 'default'`.
The glob option "as" has been deprecated in favour of "query". Please update `as: 'raw'` to `query: '?raw', import: 'default'`. (x2)
✓ 387 modules transformed.

node:internal/event_target:1100
  process.nextTick(() => { throw err; });
                           ^
TypeError [Error]: Cannot read properties of undefined (reading 'default')
    at require$2 (file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:61312:14)
    at ../node_modules/.pnpm/eslint@9.3.0/node_modules/eslint/lib/linter/rules.js (file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:91302:24)
    at __require2 (file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:61326:52)
    at ../node_modules/.pnpm/eslint@9.3.0/node_modules/eslint/lib/linter/linter.js (file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:94323:17)
    at __require2 (file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:61326:52)
    at file:///Users/baseballyama/git/eslint-plugin-svelte/docs-svelte-kit/.svelte-kit/output/server/chunks/rules2.js:95746:16
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async Promise.all (index 0)
    at async analyse (file:///Users/baseballyama/git/eslint-plugin-svelte/node_modules/.pnpm/@sveltejs+kit@2.5.9_@sveltejs+vite-plugin-svelte@3.1.0_svelte@5.0.0-next.130_vite@5.2.11/node_modules/@sveltejs/kit/src/core/postbuild/analyse.js:66:16)
Emitted 'error' event on Worker instance at:
    at [kOnErrorMessage] (node:internal/worker:326:10)
    at [kOnMessage] (node:internal/worker:337:37)
    at MessagePort.<anonymous> (node:internal/worker:232:57)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:826:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)

Node.js v20.12.1
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

Because, path between `$_injects_$$1` and usage is mismatched.
(`$_injects_$$1` starts with `./` but usage starts with `../`.)

```
const $_injects_$$1 = {
  "path": posix,
  "node:path": posix,
  "assert": $inject_node_assert,
  "node:assert": $inject_node_assert,
  "util": $inject_util,
  "./../node_modules/.pnpm/eslint@9.3.0/node_modules/eslint/lib/rules/index.js": $inject__Users_baseballyama_git_eslint_plugin_svelte_node_modules__pnpm_eslint_9_3_0_node_modules_eslint_lib_rules_index_js
};

// One of actual usage.
var builtInRules = __require$1("../node_modules/.pnpm/eslint@9.3.0/node_modules/eslint/lib/rules/index.js");
```

To prevent this, I added path normalize process in this PR.