### PR TITLE
fix: add `node:util` to resolve build errors

### DIFF
--- a/.changeset/olive-fireants-tell.md
+++ b/.changeset/olive-fireants-tell.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": patch
+---
+
+fix: add `node:util` to resolve build errors

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -204,7 +204,7 @@ function buildLinter() {
   );
   const code = build(
     linterPath,
-    ["path", "node:path", "assert", "node:assert", "util"],
+    ["path", "node:path", "assert", "node:assert", "util", "node:util"],
     {
       [rulesPath]: virtualRulesModuleId,
     },

--- a/tests/fixtures/build-test-v8/src/shim/typescript/index.ts
+++ b/tests/fixtures/build-test-v8/src/shim/typescript/index.ts
@@ -465,3 +465,5 @@ export enum Extension {
   Cts = ".cts",
   Dcts = ".d.cts",
 }
+
+export default { versionMajorMinor, TypeFlags, SyntaxKind, Extension };

--- a/tests/fixtures/build-test/src/shim/typescript/index.ts
+++ b/tests/fixtures/build-test/src/shim/typescript/index.ts
@@ -465,3 +465,5 @@ export enum Extension {
   Cts = ".cts",
   Dcts = ".d.cts",
 }
+
+export default { versionMajorMinor, TypeFlags, SyntaxKind, Extension };


### PR DESCRIPTION
This PR is needed to fix the failing GitHub Actions job at https://github.com/sveltejs/svelte-eslint-parser/actions/runs/13480582515/job/37665242710.