### PR TITLE
fix: respect regular expression aliases

### DIFF
--- a/.changeset/quiet-cats-bundle.md
+++ b/.changeset/quiet-cats-bundle.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": patch
+---
+
+Respect regular-expression aliases for Node.js built-ins.

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -150,7 +150,12 @@ export default function eslint4b(): VitePlugin {
           return false;
         }
         if (Array.isArray(configAlias)) {
-          return configAlias.some((alias) => alias.find === m);
+          return configAlias.some((alias) => {
+            if (typeof alias.find === "string") {
+              return alias.find === m;
+            }
+            return new RegExp(alias.find.source, alias.find.flags).test(m);
+          });
         }
         return (configAlias as { [find: string]: string })[m] != null;
       }

--- a/tests/src/vite-plugin-eslint4b.ts
+++ b/tests/src/vite-plugin-eslint4b.ts
@@ -4,7 +4,9 @@ import eslint4b from "../../src/vite-plugin-eslint4b";
 describe("vite-plugin-eslint4b config", () => {
   it("respects regular expression aliases for path and fs", async () => {
     const configHook = eslint4b().config;
-    assert.strictEqual(typeof configHook, "function");
+    if (typeof configHook !== "function") {
+      throw new TypeError("Expected the config hook to be a function.");
+    }
 
     const result = await configHook.call(
       {} as never,

--- a/tests/src/vite-plugin-eslint4b.ts
+++ b/tests/src/vite-plugin-eslint4b.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import eslint4b from "../../src/vite-plugin-eslint4b";
+
+describe("vite-plugin-eslint4b config", () => {
+  it("respects regular expression aliases for path and fs", async () => {
+    const configHook = eslint4b().config;
+    assert.strictEqual(typeof configHook, "function");
+
+    const result = await configHook.call(
+      {} as never,
+      {
+        resolve: {
+          alias: [
+            { find: /^(node:)?path$/u, replacement: "/path-browserify.js" },
+            { find: /^(node:)?fs$/u, replacement: "/fs-browserify.js" },
+          ],
+        },
+      },
+      { command: "serve", mode: "test" },
+    );
+
+    assert.ok(result?.resolve?.alias);
+    assert.ok(!Array.isArray(result.resolve.alias));
+    for (const moduleName of ["path", "node:path", "fs", "node:fs"]) {
+      assert.ok(!(moduleName in result.resolve.alias));
+    }
+  });
+});


### PR DESCRIPTION
Vite accepts regular expressions in array-form aliases, but vite-plugin-eslint4b only recognized exact string entries. As a result, aliases such as `/^(node:)?path$/` were overlooked and the plugin added its built-in shim over the user's replacement.

This change matches regular-expression entries using a cloned `RegExp`, so checking global or sticky expressions does not mutate their `lastIndex`. Existing string and object alias behavior remains unchanged.
