### PR TITLE
Support ESLint imports in optimized dependencies

### DIFF
--- a/.changeset/tidy-tools-rest.md
+++ b/.changeset/tidy-tools-rest.md
@@ -2,4 +2,4 @@
 "vite-plugin-eslint4b": minor
 ---
 
-Avoid dependency optimizer failures when CommonJS dependencies require ESLint.
+Avoid dependency optimizer failures when dependencies import or require ESLint.

--- a/.changeset/tidy-tools-rest.md
+++ b/.changeset/tidy-tools-rest.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-eslint4b": minor
+---
+
+Avoid dependency optimizer failures when CommonJS dependencies require ESLint.

--- a/src/vite-plugin-eslint4b.ts
+++ b/src/vite-plugin-eslint4b.ts
@@ -132,6 +132,8 @@ export default function eslint4b(): VitePlugin {
       }
 
       result.optimizeDeps = result.optimizeDeps || {};
+      result.optimizeDeps.exclude = result.optimizeDeps.exclude || [];
+      result.optimizeDeps.exclude.push("eslint", "eslint/use-at-your-own-risk");
       result.optimizeDeps.include = result.optimizeDeps.include || [];
       result.optimizeDeps.include.push(
         "@eslint-community/eslint-utils",

--- a/tests/src/vite-plugin-eslint4b.ts
+++ b/tests/src/vite-plugin-eslint4b.ts
@@ -2,6 +2,24 @@ import assert from "assert";
 import eslint4b from "../../src/vite-plugin-eslint4b";
 
 describe("vite-plugin-eslint4b config", () => {
+  it("excludes ESLint entry points from dependency optimization", async () => {
+    const configHook = eslint4b().config;
+    if (typeof configHook !== "function") {
+      throw new TypeError("Expected the config hook to be a function.");
+    }
+
+    const result = await configHook.call(
+      {} as never,
+      {},
+      { command: "serve", mode: "test" },
+    );
+
+    assert.deepStrictEqual(result?.optimizeDeps?.exclude, [
+      "eslint",
+      "eslint/use-at-your-own-risk",
+    ]);
+  });
+
   it("respects regular expression aliases for path and fs", async () => {
     const configHook = eslint4b().config;
     if (typeof configHook !== "function") {


### PR DESCRIPTION
During dependency pre-bundling, Vite applies the ESLint aliases but does not load the resulting virtual IDs through this plugin's regular hooks. Dependencies selected for optimization can therefore fail when they import `eslint` or `eslint/use-at-your-own-risk`, whether through ESM imports or CommonJS require calls.

This excludes only those two ESLint entry points from dependency optimization while keeping the existing virtual modules unchanged. ESM imports remain bare in optimized output, and Vite's CommonJS external handling converts matching require calls into bare ESM imports. The dev server then resolves both through the existing aliases and hooks, so application modules and optimized dependencies receive `Linter` and `builtinRules` from the same virtual modules.
